### PR TITLE
Return int instead of string with 'px' to allow for more math

### DIFF
--- a/layouts/fixed-columns.js
+++ b/layouts/fixed-columns.js
@@ -51,17 +51,17 @@ module.exports = function(elements, options) {
 		cols[col] += dst_height + adj;
 
 		positions.push({
-			x: (col * columnWidth + col * spacing) + 'px',
-			y: y + 'px',
-			width: dst_width + 'px',
-			height: dst_height + 'px'
+			x: (col * columnWidth + col * spacing),
+			y: y,
+			width: dst_width,
+			height: dst_height
 		});
 	}
 
 	// TODO: equalize columns w/option?
 	return {
-		width: containerWidth + 'px',
-		height: Math.max.apply(Math, cols) + 'px',
+		width: containerWidth,
+		height: Math.max.apply(Math, cols),
 		positions: positions
 	}
 };

--- a/layouts/fixed-partition.js
+++ b/layouts/fixed-partition.js
@@ -60,10 +60,10 @@ module.exports = function(elements, options) {
 		for (var i = 0; i < elementCount; i++) {
 			width = Math.round(idealHeight * aspects[i]) - (spacing * (elementCount - 1) / elementCount);
 			positions.push({
-				y: '0px',
-				x: (padLeft+xSum) + 'px',
-				width: width + 'px',
-				height: idealHeight + 'px'
+				y: 0,
+				x: padLeft + xSum,
+				width: width,
+				height: idealHeight
 			});
 			xSum += width;
 			if (i !== n - 1) {
@@ -90,10 +90,10 @@ module.exports = function(elements, options) {
 			for (j = 0; j < elementCount; j++) {
 				width = Math.round((containerWidth - (elementCount - 1) * spacing) / summedRatios * aspects[element_index + j]);
 				positions.push({
-					y: ySum + 'px',
-					x: xSum + 'px',
-					width: width + 'px',
-					height: height + 'px'
+					y: ySum,
+					x: xSum,
+					width: width,
+					height: height
 				});
 				xSum += width;
 				if (j !== elementCount - 1) {
@@ -108,8 +108,8 @@ module.exports = function(elements, options) {
 	}
 
 	return {
-		width: containerWidth + 'px',
-		height: ySum + 'px',
+		width: containerWidth,
+		height: ySum,
 		positions: positions
 	};
 };

--- a/layouts/single.js
+++ b/layouts/single.js
@@ -22,8 +22,8 @@ module.exports = function(elements, options) {
 	var padLeft = options.align === 'center' ? Math.floor((options.containerWidth - w)/2) : 0;
 
 	return {
-		width: options.containerWidth + 'px',
-		height: h + 'px',
-		positions: [{x: padLeft + 'px', y: '0px', width: w + 'px', height: h + 'px'}]
+		width: options.containerWidth,
+		height: h,
+		positions: [{x: padLeft, y: 0, width: w, height: h}]
 	};
 };


### PR DESCRIPTION
This is a really nice collection of these layout algorithms. Thanks!

I want to use this with React.js where I can pass the width, height, x,y directly to the style props like `style={{width: width, height: height}}` and so on.

Now when trying to do `style={{height: height + 15}}` with a height of 200 it shows `height="200px15"` which is a bad thing to happen.

That's why I made this pull request and removed all strings to return ints, so that the results can later be manipulated with simple math.
